### PR TITLE
Add status handling to couch sync service

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "ehealth-couch-sync",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "ehealth-couch-sync",
   "authors": [
     "eHealth Africa <ehealthehealth>"


### PR DESCRIPTION
This adds a status to the couch sync service. Status can be "sync", "online", "offline". The status can be observed using sync.onStatusChange().

The idea is to reduce the number of pouchdb event handler registrations throughout the application. This can also be used by controllers to know when they can fetch data using the views. Maybe a sync.ready() method should be used (which is called when status moves to "online").
